### PR TITLE
Remove extra trailing paren in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Google has added a clarification in its product structured data documentation ar
 <strong>Dec 15th 2020</strong> (View)
 </summary>
 <p></p>
-Google provides an update on their Structured Data Testing Tool's future. (Saved!) <a href="https://developers.google.com/search/blog/2020/12/structured-data-testing-tool-update)">Read more</a>!
+Google provides an update on their Structured Data Testing Tool's future. (Saved!) <a href="https://developers.google.com/search/blog/2020/12/structured-data-testing-tool-update">Read more</a>!
 <hr>
 </details>
 


### PR DESCRIPTION
Link is broken in rendered README as a result of extra paren.